### PR TITLE
fix: use correct cache path

### DIFF
--- a/lua/lvim/bootstrap.lua
+++ b/lua/lvim/bootstrap.lua
@@ -55,7 +55,7 @@ end
 function _G.get_cache_dir()
   local lvim_cache_dir = os.getenv "LUNARVIM_CACHE_DIR"
   if not lvim_cache_dir then
-    return vim.call("stdpath", "config")
+    return vim.call("stdpath", "cache")
   end
   return lvim_cache_dir
 end


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - [Feature]: For feature addition / improvements
 - [Bugfix]: When fixing a functionality
 - [Refactor]: When moving code without adding any functionality
 - [Doc]: On documentation updates

- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

I notice that each time use `lvim`, the following cache files appear in nvim config dir.

```
?? lsp.log
?? luacache_chunks
?? luacache_modpaths
?? lvim.shada
?? project_nvim/
```

after made the change in this commit, `lvim` stopped generated these cache files in my nvim config dir
